### PR TITLE
feat: add profile group APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,14 @@ The SDK comes with a comprehensive set of examples in the `/examples` directory,
 - `profiles/batch_reset_profile_proxy.py`: Reset proxies for multiple profiles
 - `profiles/create_profile_tags.py`: Create tags for a profile
 - `profiles/get_profile_tags.py`: Get all profile tags
-- And more tag management examples
+- `profiles/update_profile_tags.py`: Update tags for a profile
+- `profiles/batch_update_profile_tags.py`: Update tags for multiple profiles
+- `profiles/clear_profile_tags.py`: Clear all tags from a profile
+- `profiles/batch_clear_profile_tags.py`: Clear tags from multiple profiles
+- `profiles/batch_create_profile_tags.py`: Create tags for multiple profiles
+- `profiles/get_all_profile_groups.py`: Get all profile groups
+- `profiles/change_profile_group.py`: Change a profile group
+- `profiles/batch_change_profile_group.py`: Batch changes to profile groups
 
 ### Local Data Examples
 - `locals/clear_profile_cache.py`: Clear browser cache

--- a/examples/profiles/batch_change_profile_group.py
+++ b/examples/profiles/batch_change_profile_group.py
@@ -1,0 +1,24 @@
+"""
+Example demonstrating how to change groups for multiple profiles in batch.
+"""
+
+import os
+from nstbrowser import NstbrowserClient
+
+# Initialize the client with your API key
+api_key = os.environ.get("NSTBROWSER_API_KEY", "your_api_key")
+client = NstbrowserClient(api_key=api_key)
+
+# Define batch data for changing profile groups
+batch_data = {
+    "profileIds": ["profile_id_1", "profile_id_2", "profile_id_3"],
+    "groupId": "target_group_id"
+}
+
+# Change groups for multiple profiles in batch
+try:
+    response = client.profiles.batch_change_profile_group(data=batch_data)
+    print(f"Groups changed successfully for {len(batch_data['profileIds'])} profiles")
+    print("Response:", response)
+except Exception as e:
+    print(f"Failed to change profile groups in batch: {e}")

--- a/examples/profiles/change_profile_group.py
+++ b/examples/profiles/change_profile_group.py
@@ -1,0 +1,22 @@
+"""
+Example demonstrating how to change a profile's group.
+"""
+
+import os
+from nstbrowser import NstbrowserClient
+
+# Initialize the client with your API key
+api_key = os.environ.get("NSTBROWSER_API_KEY", "your_api_key")
+client = NstbrowserClient(api_key=api_key)
+
+# Define profile ID and target group ID
+profile_id = "your_profile_id"
+group_id = "target_group_id"
+
+# Change the profile's group
+try:
+    response = client.profiles.change_profile_group(profile_id=profile_id, group_id=group_id)
+    print(f"Profile {profile_id} moved to group {group_id} successfully")
+    print("Response:", response)
+except Exception as e:
+    print(f"Failed to change profile group: {e}")

--- a/examples/profiles/get_all_profile_groups.py
+++ b/examples/profiles/get_all_profile_groups.py
@@ -1,0 +1,23 @@
+"""
+Example demonstrating how to get all profile groups.
+"""
+
+import os
+from nstbrowser import NstbrowserClient
+
+# Initialize the client with your API key
+api_key = os.environ.get("NSTBROWSER_API_KEY", "your_api_key")
+client = NstbrowserClient(api_key=api_key)
+
+# Get all profile groups
+try:
+    response = client.profiles.get_all_profile_groups()
+    print("All profile groups retrieved successfully")
+    print("Response:", response)
+    
+    # Optionally, you can filter by group name
+    group_name = "MyGroup"
+    filtered_response = client.profiles.get_all_profile_groups(group_name=group_name)
+    print(f"Profile groups filtered by name '{group_name}':", filtered_response)
+except Exception as e:
+    print(f"Failed to get profile groups: {e}")

--- a/nstbrowser/services/profiles.py
+++ b/nstbrowser/services/profiles.py
@@ -47,3 +47,12 @@ class ProfilesService(BaseService):
 
     def get_profiles(self, data: dict | None = None):
         return self._client._get(f"/profiles", data)
+
+    def get_all_profile_groups(self, group_name: str | None = None):
+        return self._client._get("/profiles/groups", {"groupName": group_name})
+
+    def change_profile_group(self, profile_id: str, group_id: str):
+        return self._client._put(f"/profiles/{profile_id}/group", {"groupId": group_id})
+      
+    def batch_change_profile_group(self, data: dict):
+        return self._client._put("/profiles/group/batch", data)


### PR DESCRIPTION
### adds new profile group management APIs to ProfilesService:

*  Added new APIs:
   - get_all_profile_groups: Get all profile groups
   - chanage_profile_group: Change group for a single profile
   - batch_change_profile_group: Change group for multiple profiles in batch

* Added example files:
   - profiles/get_all_profile_groups.py
   - profiles/change_profile_group.py  
   - profiles/batch_change_profile_group.py